### PR TITLE
Minify @b/itwin-client AccessToken usage.

### DIFF
--- a/packages/app/.env
+++ b/packages/app/.env
@@ -1,8 +1,4 @@
 # ---- Authorization Client Settings ----
 # See README.md for client Id generation steps
 IMJS_AUTH_CLIENT_CLIENT_ID=
-IMJS_AUTH_CLIENT_SCOPES="imodels:read imodels:modify projects:read projects:modify storage:read storage:modify synchronization:read synchronization:modify openid email profile organization itwinjs"
-
-# ---- Demo Portal Whitelist ----
-# Space separated list of organization id from ims (can be retrieved as orgId in the token)
-IMJS_DEMO_PORTAL_WHITELIST=
+IMJS_AUTH_CLIENT_SCOPES="imodels:read imodels:modify projects:read projects:modify storage:read storage:modify synchronization:read synchronization:modify itwinjs savedviews:read savedviews:modify"

--- a/packages/app/src/components/Auth/AuthProvider.tsx
+++ b/packages/app/src/components/Auth/AuthProvider.tsx
@@ -4,17 +4,18 @@
  *
  * This code is for demonstration purposes and should not be considered production ready.
  *--------------------------------------------------------------------------------------------*/
-import { AccessToken, UserInfo } from "@bentley/itwin-client";
+import { UserInfo } from "@bentley/itwin-client";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 
 import { useConfig } from "../../config/ConfigProvider";
 import AuthClient from "../../services/auth/AuthClient";
+import { getClaimsFromToken } from "../../services/auth/authUtils";
 import { ai } from "../../services/telemetry";
 
 export interface AuthContextValue {
   isAuthenticated: boolean;
   isAuthorized: boolean;
-  accessToken?: AccessToken;
+  accessToken?: string;
   userInfo?: UserInfo;
   signOut: () => void;
 }
@@ -32,7 +33,7 @@ const AuthContext = React.createContext<AuthContextValue>({
 });
 
 export const AuthProvider = ({ children }: AuthProviderProps) => {
-  const [accessToken, setAccessToken] = useState<AccessToken>();
+  const [accessToken, setAccessToken] = useState<string>();
   const [userInfo, setUserInfo] = useState<UserInfo>();
 
   const { auth } = useConfig();
@@ -49,9 +50,12 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
           );
         }
         const client = AuthClient.initialize(auth.clientId, auth.authority);
-        client.onUserStateChanged.addListener((token?: AccessToken) => {
-          setAccessToken(token);
-          const userInfo = token?.getUserInfo();
+        client.onUserStateChanged.addListener((token) => {
+          const tokenString = token?.toTokenString();
+          setAccessToken(tokenString);
+          const userInfo = UserInfo.fromTokenResponseJson(
+            getClaimsFromToken(tokenString ?? "")
+          );
           setUserInfo(userInfo);
           ai.updateUserInfo(userInfo);
         });
@@ -75,15 +79,15 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
 
   const isAuthorized = useMemo(() => {
     if (auth?.whitelistedIds) {
-      if (userInfo?.organization?.id) {
+      const tokenObject = getClaimsFromToken(accessToken ?? "");
+      if (tokenObject?.org) {
         const whitelist = auth.whitelistedIds.split(" ");
-        const orgId = userInfo.organization?.id;
-        return whitelist.includes(orgId);
+        return whitelist.includes(tokenObject?.org);
       }
       return false;
     }
     return true;
-  }, [auth, userInfo]);
+  }, [accessToken, auth]);
 
   const signOut = useCallback(async () => {
     await AuthClient.signOut();

--- a/packages/app/src/components/Header/Header.tsx
+++ b/packages/app/src/components/Header/Header.tsx
@@ -4,7 +4,6 @@
  *
  * This code is for demonstration purposes and should not be considered production ready.
  *--------------------------------------------------------------------------------------------*/
-import { AccessToken } from "@bentley/itwin-client";
 import {
   SvgImageFrame,
   SvgImodelHollow,
@@ -32,7 +31,7 @@ import { VersionHeaderButton } from "./VersionHeaderButton";
 
 interface HeaderProps {
   isAuthenticated: boolean;
-  accessToken?: AccessToken;
+  accessToken?: string;
   handleLogout: () => void;
 }
 
@@ -96,7 +95,7 @@ const RoutedHeader = ({
                   key="project"
                   projectId={projectId}
                   section={section}
-                  accessToken={accessToken?.toTokenString()}
+                  accessToken={accessToken}
                   isActive={!iModelId || section === "members"}
                 />
               )
@@ -107,7 +106,7 @@ const RoutedHeader = ({
                   key="iModel"
                   iModelId={iModelId}
                   projectId={projectId}
-                  accessToken={accessToken?.toTokenString()}
+                  accessToken={accessToken}
                   section={section}
                 />
               )
@@ -119,7 +118,7 @@ const RoutedHeader = ({
                   iModelId={iModelId}
                   projectId={projectId}
                   versionId={versionMatch?.versionId}
-                  accessToken={accessToken?.toTokenString()}
+                  accessToken={accessToken}
                   section={section}
                 />
               )
@@ -141,7 +140,7 @@ const RoutedHeader = ({
       userIcon={
         isAuthenticated && (
           <HeaderUserIcon
-            accessTokenObject={accessToken}
+            accessToken={accessToken}
             handleLogout={handleLogout}
           />
         )

--- a/packages/app/src/components/Header/HeaderUserIcon.tsx
+++ b/packages/app/src/components/Header/HeaderUserIcon.tsx
@@ -4,7 +4,6 @@
  *
  * This code is for demonstration purposes and should not be considered production ready.
  *--------------------------------------------------------------------------------------------*/
-import { AccessToken } from "@bentley/itwin-client";
 import {
   Body,
   DropdownMenu,
@@ -17,49 +16,53 @@ import {
 } from "@itwin/itwinui-react";
 import React from "react";
 
+import { getClaimsFromToken } from "../../services/auth/authUtils";
 import "./HeaderUserIcon.scss";
 
 interface HeaderUserIconProps {
-  accessTokenObject?: AccessToken;
+  accessToken?: string;
   handleLogout?: () => void;
 }
 
 export const HeaderUserIcon = ({
-  accessTokenObject,
+  accessToken,
   handleLogout,
 }: HeaderUserIconProps) => {
   const [userIconProps, setUserIconProps] = React.useState<
     Partial<UserIconProps>
   >({});
-  const { email, profile, organization } =
-    accessTokenObject?.getUserInfo() ?? {};
+  const [claims, setClaims] = React.useState<Record<string, string>>({});
+
+  React.useEffect(() => {
+    setClaims(getClaimsFromToken(accessToken ?? "") ?? {});
+  }, [accessToken]);
 
   React.useEffect(() => {
     setUserIconProps({
       abbreviation:
-        (profile?.firstName.toLocaleUpperCase()?.[0] ?? "") +
-        (profile?.lastName.toLocaleUpperCase()?.[0] ?? ""),
-      backgroundColor: getUserColor(email?.id ?? "Unknown"),
+        (claims.given_name?.toLocaleUpperCase()?.[0] ?? "") +
+        (claims.family_name?.toLocaleUpperCase()?.[0] ?? ""),
+      backgroundColor: getUserColor(claims.email ?? "Unknown"),
     });
-  }, [profile, email]);
+  }, [claims]);
 
   return (
     <DropdownMenu
       menuItems={(close) => [
         <div key={"description"} className={"user-panel"}>
           <Body style={{ marginBottom: 5 }}>
-            {profile?.firstName ?? ""} {profile?.lastName ?? ""}
+            {claims.given_name ?? ""} {claims.family_name ?? ""}
           </Body>
           <Small>
-            {email?.id ?? ""}
-            {organization?.name && <br />}
-            {organization?.name ?? ""}
+            {claims.email ?? ""}
+            {claims.org_name && <br />}
+            {claims.org_name ?? ""}
           </Small>
         </div>,
         <MenuItem
           key={"token"}
           onClick={() => {
-            const token = accessTokenObject?.toTokenString() ?? "";
+            const token = accessToken ?? "";
             navigator.clipboard.writeText(token).catch(() => {
               //Noop
             });

--- a/packages/app/src/components/MainApp.tsx
+++ b/packages/app/src/components/MainApp.tsx
@@ -4,7 +4,6 @@
  *
  * This code is for demonstration purposes and should not be considered production ready.
  *--------------------------------------------------------------------------------------------*/
-import { IncludePrefix } from "@bentley/itwin-client";
 import { ErrorPage, Text } from "@itwin/itwinui-react";
 import React from "react";
 
@@ -31,10 +30,8 @@ export const MainApp = () => {
     >
       {isAuthenticated ? (
         isAuthorized ? (
-          <SynchronizationAPIProvider
-            accessToken={accessToken?.toTokenString(IncludePrefix.Yes) ?? ""}
-          >
-            <MainRouter accessToken={accessToken} />
+          <SynchronizationAPIProvider accessToken={accessToken ?? ""}>
+            <MainRouter accessToken={accessToken ?? ""} />
           </SynchronizationAPIProvider>
         ) : (
           <ErrorPage errorType="401" />

--- a/packages/app/src/routers/MainRouter.tsx
+++ b/packages/app/src/routers/MainRouter.tsx
@@ -4,9 +4,8 @@
  *
  * This code is for demonstration purposes and should not be considered production ready.
  *--------------------------------------------------------------------------------------------*/
-import { AccessToken } from "@bentley/itwin-client";
 import { Redirect, Router } from "@reach/router";
-import React, { useMemo } from "react";
+import React from "react";
 
 import { ManageVersionsRouter } from "./ManageVersionsRouter/ManageVersionsRouter";
 import { MembersRouter } from "./MembersRouter/MembersRouter";
@@ -15,27 +14,20 @@ import { SynchronizationRouter } from "./SynchronizationRouter/SynchronizationRo
 import { ViewRouter } from "./ViewRouter/ViewRouter";
 
 interface MainRouterProps {
-  accessToken?: AccessToken;
+  accessToken: string;
 }
 
 export const MainRouter = ({ accessToken }: MainRouterProps) => {
-  const accessTokenStr = useMemo(() => {
-    return accessToken?.toTokenString() ?? "";
-  }, [accessToken]);
-
   return (
     <Router className={"full-height-container"}>
-      <ViewRouter accessToken={accessTokenStr} path="view/*" />
-      <SynchronizationRouter
-        path="synchronize/*"
-        accessToken={accessTokenStr}
-      />
-      <SavedviewsRouter path="savedviews/*" accessToken={accessTokenStr} />
+      <ViewRouter accessToken={accessToken} path="view/*" />
+      <SynchronizationRouter path="synchronize/*" accessToken={accessToken} />
+      <SavedviewsRouter path="savedviews/*" accessToken={accessToken} />
       <ManageVersionsRouter
         path="manage-versions/*"
-        accessToken={accessTokenStr}
+        accessToken={accessToken}
       />
-      <MembersRouter path="members/*" accessToken={accessTokenStr} />
+      <MembersRouter path="members/*" accessToken={accessToken} />
       <Redirect noThrow={true} from="/" to="view" default={true} />
     </Router>
   );

--- a/packages/app/src/services/auth/authUtils.ts
+++ b/packages/app/src/services/auth/authUtils.ts
@@ -1,0 +1,19 @@
+/*---------------------------------------------------------------------------------------------
+ * Copyright (c) Bentley Systems, Incorporated. All rights reserved.
+ * See LICENSE.md in the project root for license terms and full copyright notice.
+ *
+ * This code is for demonstration purposes and should not be considered production ready.
+ *--------------------------------------------------------------------------------------------*/
+/**
+ * Returns the main part of a JWT as an object.
+ * @param token OAuth JWT
+ * @returns Object, or undefined if cant be parsed.
+ */
+export const getClaimsFromToken = (token: string) => {
+  const [, body] = token.split(".");
+  try {
+    return JSON.parse(atob(body));
+  } catch {
+    return undefined;
+  }
+};


### PR DESCRIPTION
This removes the requirements of profile/email/organization/openid scopes to be present in the token while keeping the same functionality from a "bare" token.

Note: Now building `UserInfo` from internal `UserInfo.fromTokenResponseJson` instead of relying on AccessToken which relies on the "profile" scope to be available for the client.